### PR TITLE
feat: add plugin logs page

### DIFF
--- a/src/usr/local/emhttp/plugins/enhanced.log/PluginLogs.page
+++ b/src/usr/local/emhttp/plugins/enhanced.log/PluginLogs.page
@@ -1,0 +1,32 @@
+Menu="EnhancedLog:2"
+Title="Plugin Logs"
+Icon="align-left"
+Markdown="false"
+---
+<?php
+
+/*
+    Copyright (C) 2025  Derek Kaser
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+try {
+    $docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
+    require_once "{$docroot}/plugins/enhanced.log/include/page.php";
+
+    echo EDACerton\EnhancedLog\getPage("PluginLogs", true, array());
+} catch (Throwable $e) {
+    echo "An error occurred: <pre>" . print_r($e, true) . "</pre>";
+}

--- a/src/usr/local/emhttp/plugins/enhanced.log/assets/enhancedlog.js
+++ b/src/usr/local/emhttp/plugins/enhanced.log/assets/enhancedlog.js
@@ -90,6 +90,36 @@ DataTable.feature.register("logSelect", function (settings, opts) {
   return toolbar;
 });
 
+DataTable.feature.register("pluginSelect", function (settings, opts) {
+  let toolbar = document.createElement("div");
+  toolbar.appendChild(document.createTextNode(`${translator.tr("log")}: `));
+
+  const logSelect = document.createElement("select");
+  logSelect.id = "log-select-" + settings.sTableId;
+  logSelect.name = "log-select-" + settings.sTableId;
+
+  const noneOption = document.createElement("option");
+  noneOption.value = "";
+  noneOption.textContent = "";
+  logSelect.appendChild(noneOption);
+
+  for (const [key, value] of Object.entries(pluginFiles)) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = key;
+    logSelect.appendChild(option);
+  }
+
+  toolbar.appendChild(logSelect);
+
+  logSelect.addEventListener("change", function (e) {
+    const newUrl = opts.baseURL + "?log=" + encodeURIComponent(e.target.value);
+    settings.api.ajax.url(newUrl).load();
+  });
+
+  return toolbar;
+});
+
 const columnSaving = {
   columns: {
     search: true,
@@ -344,6 +374,81 @@ function getSummaryConfig(url) {
       if (data["textColor"] != "") {
         row.style.color = data.textColor;
       }
+    },
+  };
+}
+
+function getPluginConfig(url) {
+  return {
+    ajax: {
+      url: url,
+      dataSrc: "",
+    },
+    order: [[0, "desc"]],
+    columns: [
+      { name: "sequence", data: "sequence" },
+      { name: "line", data: "line" },
+    ],
+    columnDefs: [
+      {
+        targets: 0,
+        width: 1,
+        className: "dt-left",
+        columnControl: {
+          target: 0,
+          content: [],
+        },
+      },
+      {
+        targets: 1,
+        className: "overflow-anywhere",
+        columnControl: {
+          target: 0,
+          content: [
+            {
+              extend: "dropdown",
+              content: ["searchClear", "search"],
+              icon: "search",
+            },
+          ],
+        },
+      },
+    ],
+    paging: true,
+    pageLength: 50,
+    ordering: true,
+    stateSave: true,
+    layout: {
+      topStart: {
+        buttons: [
+          {
+            text: translator.tr("refresh"),
+            action: function (e, dt, node, config) {
+              dt.ajax.reload();
+            },
+          },
+          {
+            extend: "csv",
+            text: translator.tr("download"),
+          },
+          "copy",
+          {
+            text: translator.tr("clear_filters"),
+            action: function (e, dt, node, config) {
+              dt.search("");
+              dt.columns().ccSearchClear();
+              dt.draw();
+            },
+          },
+        ],
+        pluginSelect: {
+          baseURL: url,
+        },
+        pageLength: {
+          menu: [25, 50, 100, 200, -1],
+        },
+      },
+      topEnd: {},
     },
   };
 }

--- a/src/usr/local/emhttp/plugins/enhanced.log/data.php
+++ b/src/usr/local/emhttp/plugins/enhanced.log/data.php
@@ -47,6 +47,46 @@ $app->get("{$prefix}/files", function (Request $request, Response $response, $ar
         ->withStatus(200);
 });
 
+$app->get("{$prefix}/pluginFiles", function (Request $request, Response $response, $args) {
+    $plugins = new Plugins();
+    $logs    = $plugins->getFiles();
+    $payload = json_encode($logs) ?: "[]";
+    $response->getBody()->write($payload);
+    return $response
+        ->withHeader('Content-Type', 'application/json')
+        ->withHeader('Cache-Control', 'no-store')
+        ->withStatus(200);
+});
+
+$app->get("{$prefix}/pluginLog", function (Request $request, Response $response, $args) {
+    // Get the log file name from the query parameters
+    $body = (array) $request->getQueryParams();
+
+    $payload = array();
+
+    // Get the log file via Plugins class
+    $plugins = new Plugins();
+    $logData = $plugins->getFile($body['log'] ?? '');
+
+    // Split the log data into lines, then add each line to the payload with its sequence number
+    if ($logData !== null) {
+        $lines = explode("\n", $logData);
+        foreach ($lines as $sequence => $line) {
+            if (trim($line) !== '') { // Skip empty lines
+                $payload[] = [
+                    'sequence' => $sequence,
+                    'line'     => trim($line)
+                ];
+            }
+        }
+    }
+    $response->getBody()->write(json_encode($payload) ?: "[]");
+    return $response
+        ->withHeader('Content-Type', 'application/json')
+        ->withHeader('Cache-Control', 'no-store')
+        ->withStatus(200);
+});
+
 $app->get("{$prefix}/log", function (Request $request, Response $response, $args) {
     $body = (array) $request->getQueryParams();
 

--- a/src/usr/local/emhttp/plugins/enhanced.log/include/Pages/EnhancedSyslog.php
+++ b/src/usr/local/emhttp/plugins/enhanced.log/include/Pages/EnhancedSyslog.php
@@ -32,6 +32,9 @@ $tr = $tr ?? new Translator(PLUGIN_ROOT);
 
 $logs = Utils::getLogFiles();
 
+$plugins     = new Plugins();
+$pluginFiles = $plugins->getFiles();
+
 $enhanced_log_cfg = Utils::getConfig();
 $colors           = new Colors();
 $colors->parseConfig($enhanced_log_cfg);
@@ -48,6 +51,11 @@ if (in_array($theme ?? "", $themeArray)) {
 <script>
 const logFiles = <?= json_encode(
     array_combine(array_map('basename', $logs), $logs),
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+); ?>;
+
+const pluginFiles = <?= json_encode(
+    array_combine(array_map('basename', $pluginFiles), $pluginFiles),
     JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
 ); ?>;
 </script>
@@ -87,6 +95,7 @@ $(document).ready( async function () {
     await translator.init();
     $('#logTable').DataTable(getDatatableConfig('/plugins/enhanced.log/data.php/log'));
     $('#summaryTable').DataTable(getSummaryConfig('/plugins/enhanced.log/data.php/summary'));
+    $('#pluginTable').DataTable(getPluginConfig('/plugins/enhanced.log/data.php/pluginLog'));
 } );
 
 <?php foreach ($colors->getColors() as $color) { ?>

--- a/src/usr/local/emhttp/plugins/enhanced.log/include/Pages/PluginLogs.php
+++ b/src/usr/local/emhttp/plugins/enhanced.log/include/Pages/PluginLogs.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EDACerton\EnhancedLog;
+
+use EDACerton\PluginUtils\Translator;
+
+/*
+    Copyright (C) 2025  Derek Kaser
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+if ( ! defined(__NAMESPACE__ . '\PLUGIN_ROOT') || ! defined(__NAMESPACE__ . '\PLUGIN_NAME')) {
+    throw new \RuntimeException("Common file not loaded.");
+}
+
+$tr = $tr ?? new Translator(PLUGIN_ROOT);
+
+?>
+
+<table id='pluginTable' class="stripe compact">
+    <thead>
+        <tr>
+            <th><strong><?= $tr->tr("line"); ?></strong></th>
+            <th><strong><?= $tr->tr("message"); ?></strong></th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+    <tfoot>
+    </tfoot>
+</table>

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/de_DE.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/de_DE.json
@@ -25,6 +25,7 @@
     "clear_filters": "Filter löschen",
     "save": "Filter speichern",
     "load": "Laden",
+    "line": "Zeilennummer",
     "configuration": {
         "syslog_config": "Syslog-Konfiguration",
         "show_all_lines": "Alle Zeilen im Log anzeigen",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/en_US.json
@@ -25,6 +25,7 @@
     "clear_filters": "Clear Filters",
     "save": "Save Filters",
     "load": "Load",
+    "line": "Line Number",
     "configuration": {
         "syslog_config": "Syslog Configuration",
         "show_all_lines": "Show All Lines in Log",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/es_ES.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/es_ES.json
@@ -25,6 +25,7 @@
     "clear_filters": "Borrar filtros",
     "save": "Guardar filtros",
     "load": "Cargar",
+    "line": "Número de línea",
     "configuration": {
         "syslog_config": "Configuración de Syslog",
         "show_all_lines": "Mostrar todas las líneas en el registro",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/fr_FR.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/fr_FR.json
@@ -25,6 +25,7 @@
     "clear_filters": "Effacer les filtres",
     "save": "Enregistrer les filtres",
     "load": "Charger",
+    "line": "Numéro de ligne",
     "configuration": {
         "syslog_config": "Configuration Syslog",
         "show_all_lines": "Afficher toutes les lignes du journal",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/it_IT.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/it_IT.json
@@ -25,6 +25,7 @@
     "clear_filters": "Cancella filtri",
     "save": "Salva filtri",
     "load": "Carica",
+    "line": "Numero di riga",
     "configuration": {
         "syslog_config": "Configurazione Syslog",
         "show_all_lines": "Mostra tutte le righe nel log",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/ja_JP.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/ja_JP.json
@@ -25,6 +25,7 @@
     "clear_filters": "フィルターをクリア",
     "save": "フィルターを保存",
     "load": "読み込む",
+    "line": "行番号",
     "configuration": {
         "syslog_config": "Syslog設定",
         "show_all_lines": "ログの全行を表示",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/ko_KR.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/ko_KR.json
@@ -25,6 +25,7 @@
     "clear_filters": "필터 초기화",
     "save": "필터 저장",
     "load": "불러오기",
+    "line": "줄 번호",
     "configuration": {
         "syslog_config": "Syslog 구성",
         "show_all_lines": "로그의 모든 줄 표시",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/nl_NL.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/nl_NL.json
@@ -25,6 +25,7 @@
     "clear_filters": "Filters wissen",
     "save": "Filters opslaan",
     "load": "Laden",
+    "line": "Regelnummer",
     "configuration": {
         "syslog_config": "Syslog-configuratie",
         "show_all_lines": "Alle regels in log weergeven",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/no_NO.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/no_NO.json
@@ -25,6 +25,7 @@
     "clear_filters": "Fjern filtre",
     "save": "Lagre filtre",
     "load": "Last inn",
+    "line": "Linjenummer",
     "configuration": {
         "syslog_config": "Syslog-konfigurasjon",
         "show_all_lines": "Vis alle linjer i loggen",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/pl_PL.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/pl_PL.json
@@ -25,6 +25,7 @@
     "clear_filters": "Wyczyść filtry",
     "save": "Zapisz filtry",
     "load": "Wczytaj",
+    "line": "Numer linii",
     "configuration": {
         "syslog_config": "Konfiguracja Syslog",
         "show_all_lines": "Pokaż wszystkie linie w logu",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/pt_BR.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/pt_BR.json
@@ -25,6 +25,7 @@
     "clear_filters": "Limpar filtros",
     "save": "Salvar filtros",
     "load": "Carregar",
+    "line": "Número da Linha",
     "configuration": {
         "syslog_config": "Configuração do Syslog",
         "show_all_lines": "Mostrar Todas as Linhas no Log",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/pt_PT.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/pt_PT.json
@@ -25,6 +25,7 @@
     "clear_filters": "Limpar filtros",
     "save": "Salvar filtros",
     "load": "Carregar",
+    "line": "Número da Linha",
     "configuration": {
         "syslog_config": "Configuração do Syslog",
         "show_all_lines": "Mostrar Todas as Linhas no Log",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/sv_SE.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/sv_SE.json
@@ -25,6 +25,7 @@
     "clear_filters": "Rensa filter",
     "save": "Spara filter",
     "load": "Ladda",
+    "line": "Radnummer",
     "configuration": {
         "syslog_config": "Syslog-konfiguration",
         "show_all_lines": "Visa alla rader i loggen",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/uk_UA.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/uk_UA.json
@@ -25,6 +25,7 @@
     "clear_filters": "Очистити фільтри",
     "save": "Зберегти фільтри",
     "load": "Завантажити",
+    "line": "Номер рядка",
     "configuration": {
         "syslog_config": "Конфігурація Syslog",
         "show_all_lines": "Показати всі рядки в журналі",

--- a/src/usr/local/emhttp/plugins/enhanced.log/locales/zh_CN.json
+++ b/src/usr/local/emhttp/plugins/enhanced.log/locales/zh_CN.json
@@ -25,6 +25,7 @@
     "clear_filters": "清除筛选器",
     "save": "保存筛选器",
     "load": "加载",
+    "line": "行号",
     "configuration": {
         "syslog_config": "Syslog 配置",
         "show_all_lines": "显示日志中的所有行",

--- a/src/usr/local/php/unraid-enhancedlog/unraid-enhancedlog/Plugins.php
+++ b/src/usr/local/php/unraid-enhancedlog/unraid-enhancedlog/Plugins.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace EDACerton\EnhancedLog;
+
+/*
+    Copyright (C) 2025  Derek Kaser
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+class Plugins
+{
+    /** @var array<string> $files */
+    private array $files = [];
+
+    public function __construct()
+    {
+        $this->files = $this->findLogFiles();
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getFiles(): array
+    {
+        return $this->files;
+    }
+
+    public function getFile(string $file): ?string
+    {
+        if (in_array($file, $this->files)) {
+            // Read the content of the file and return it. If the file ends in .gz, decompress it first.
+            if (str_ends_with($file, '.gz')) {
+                $content = file_get_contents("compress.zlib://{$file}");
+            } else {
+                $content = file_get_contents($file);
+            }
+
+            if ($content !== false) {
+                return $content;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function findLogFiles(): array
+    {
+        $path  = ['/usr/local/emhttp/plugins/','/enhanced-log.json'];
+        $files = array();
+
+        foreach (glob("{$path[0]}*{$path[1]}") ?: array() as $file) {
+            try {
+                $data = (object) json_decode(file_get_contents($file) ?: "{}", false);
+
+                if ( ! isset($data->files)) {
+                    continue;
+                }
+
+                // Glob each entry in the files array. Add any found files to the list.
+                foreach ($data->files as $glob) {
+                    $foundFiles = glob($glob) ?: array();
+                    foreach ($foundFiles as $foundFile) {
+                        if (is_file($foundFile)) {
+                            $files[] = $foundFile;
+                        }
+                    }
+                }
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+        return $files;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Plugin Logs" interface to view and filter log files generated by installed plugins.
  * Added a dropdown menu for selecting specific plugin logs, with dynamic loading and filtering.
  * Provided CSV export, copy, and filter clearing options for plugin log tables.
  * Added support for displaying line numbers alongside log messages.

* **Localization**
  * Added translations for "Line Number" in multiple languages, enhancing internationalization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->